### PR TITLE
 Use $CHANGE variable; add namespace to function names

### DIFF
--- a/changelog-helpers.sh
+++ b/changelog-helpers.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function title {
+function _changelogsh_title {
   input=$1
   echo $(echo ${input:0:1} | tr  '[a-z]' '[A-Z]')${input:1}
 }

--- a/changelog-init.sh
+++ b/changelog-init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function init {
+function _changelogsh_init {
   if [ ! -d 'changelog' ]; then
     mkdir 'changelog'
   fi

--- a/changelog-new.sh
+++ b/changelog-new.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function new {
+function _changelogsh_new {
 
   timestamp=$(date +"%Y%m%d%H%M%S")
   type='fixed'

--- a/changelog-preview.sh
+++ b/changelog-preview.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-source ~/.change/changelog-helpers.sh
-
-function preview {
+function _changelogsh_preview {
   version="Unreleased"
   if [ "$#" -gt 0 ]; then
     version=$1
@@ -20,7 +18,7 @@ function preview {
   for dir in changelog/$version/*; do
     if [ "$(ls -A $dir)" ]; then
       current=$(echo $dir | grep -o '[^/]*$')
-      echo "###" $(title $current)
+      echo "###" $(_changelogsh_title $current)
       for file in $dir/*; do
         echo "-" $(cat $file)
       done

--- a/changelog-release.sh
+++ b/changelog-release.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-source ~/.change/changelog-preview.sh
 
-function release {
+function _changelogsh_release {
 
   if [ ! -d "changelog/unreleased/" ]; then
     printf "Nothing to release.\n"

--- a/changelog-release.sh
+++ b/changelog-release.sh
@@ -13,5 +13,5 @@ function _changelogsh_release {
   fi
 
   mv 'changelog/unreleased' "changelog/$1"
-  preview $1
+  _changelogsh_preview $1
 }

--- a/changelog-unrelease.sh
+++ b/changelog-unrelease.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-source ~/.change/changelog-preview.sh
-
-function unrelease {
+function _changelogsh_unrelease {
 
   if [ "$#" -eq 0 ]; then
     echo "Version is required"

--- a/changelog-unrelease.sh
+++ b/changelog-unrelease.sh
@@ -21,5 +21,5 @@ function _changelogsh_unrelease {
   mv changelog/$version/* changelog/unreleased/
   rm -r changelog/$version
 
-  preview
+  _changelogsh_preview
 }

--- a/changelog-upgrade.sh
+++ b/changelog-upgrade.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function upgrade {
+function _changelogsh_upgrade {
   if [ ! -n "$CHANGE" ]; then
     CHANGE=~/.change
   fi

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
-source ~/.change/changelog-init.sh
-source ~/.change/changelog-new.sh
-source ~/.change/changelog-preview.sh
-source ~/.change/changelog-release.sh
-source ~/.change/changelog-unrelease.sh
-source ~/.change/changelog-upgrade.sh
+if [ ! -n "$CHANGE" ]; then
+  CHANGE=~/.change
+fi
 
-function changelog {
+source $CHANGE/changelog-helpers.sh
+
+source $CHANGE/changelog-init.sh
+source $CHANGE/changelog-new.sh
+source $CHANGE/changelog-preview.sh
+source $CHANGE/changelog-release.sh
+source $CHANGE/changelog-unrelease.sh
+source $CHANGE/changelog-upgrade.sh
+
+function _changelogsh_changelog {
   usage="usage: change <command> [<args>]
   
   These are the available commands:
@@ -25,32 +31,32 @@ function changelog {
   fi
 
   if [ $1 == 'init' ]; then
-    init ${@:2}
+    _changelogsh_init ${@:2}
     return
   fi
 
   if [ $1 == 'new' ]; then
-    new ${@:2}
+    _changelogsh_new ${@:2}
     return
   fi
 
   if [ $1 == 'preview' ]; then
-    preview ${@:2}
+    _changelogsh_preview ${@:2}
     return
   fi
 
   if [ $1 == 'release' ]; then
-    release ${@:2}
+    _changelogsh_release ${@:2}
     return
   fi
 
   if [ $1 == 'unrelease' ]; then
-    unrelease ${@:2}
+    _changelogsh_unrelease ${@:2}
     return
   fi
 
   if [ $1 == 'upgrade' ]; then
-    upgrade ${@:2}
+    _changelogsh_upgrade ${@:2}
     return
   fi
 
@@ -58,4 +64,4 @@ function changelog {
   printf "$usage"
 }
 
-changelog $@
+_changelogsh_changelog $@

--- a/changelog.sh
+++ b/changelog.sh
@@ -13,7 +13,7 @@ source $CHANGE/changelog-release.sh
 source $CHANGE/changelog-unrelease.sh
 source $CHANGE/changelog-upgrade.sh
 
-function _changelogsh_changelog {
+function _changelogsh_main {
   usage="usage: change <command> [<args>]
   
   These are the available commands:
@@ -64,4 +64,4 @@ function _changelogsh_changelog {
   printf "$usage"
 }
 
-_changelogsh_changelog $@
+_changelogsh_main $@


### PR DESCRIPTION
Since we're using `$CHANGE` variable for installation, the source should align with it.

Plus, adding namespace to the function seems like a good thing to do. 😉 

fix #11 