### PR TITLE
Add order in the changelog directory by formating it by adding leading zeroes

### DIFF
--- a/changelog-helpers.sh
+++ b/changelog-helpers.sh
@@ -4,3 +4,16 @@ function _changelogsh_title {
   input=$1
   echo $(echo ${input:0:1} | tr  '[a-z]' '[A-Z]')${input:1}
 }
+
+function _changelogsh_raw_to_expanded {
+  input="$1"
+  split=("${input//./ }")
+  echo $split | xargs printf '%03d'
+}
+
+function _changelogsh_expanded_to_raw {
+  input=$1
+  split=($(echo $input | fold -w3))
+
+  echo $split | sed 's/^0*//g; s/ 0*/./g'
+}

--- a/changelog-preview.sh
+++ b/changelog-preview.sh
@@ -1,21 +1,26 @@
 #!/bin/bash
 
 function _changelogsh_preview {
-  version="Unreleased"
+  raw_version="Unreleased"
+  expanded="Unreleased"
   if [ "$#" -gt 0 ]; then
-    version=$1
+    raw_version=$1
   fi
 
-  if [ ! -d "changelog/$version" ]; then
-    printf "$version not found.\n"
+  if [ $raw_version != "Unreleased" ]; then
+    expanded=$(_changelogsh_raw_to_expanded $raw_version)
+  fi
+
+  if [ ! -d "changelog/$expanded" ]; then
+    printf "$raw_version not found.\n"
     return
   fi
 
   echo "# What's new?"
   echo ""
-  echo "## [$version]"
+  echo "## [$raw_version]"
 
-  for dir in changelog/$version/*; do
+  for dir in changelog/$expanded/*; do
     if [ "$(ls -A $dir)" ]; then
       current=$(echo $dir | grep -o '[^/]*$')
       echo "###" $(_changelogsh_title $current)

--- a/changelog-release.sh
+++ b/changelog-release.sh
@@ -12,6 +12,9 @@ function _changelogsh_release {
     return
   fi
 
-  mv 'changelog/unreleased' "changelog/$1"
+  version=$1
+  expanded=$(_changelogsh_raw_to_expanded $version)
+
+  mv 'changelog/unreleased' "changelog/$expanded"
   _changelogsh_preview $1
 }

--- a/changelog-unrelease.sh
+++ b/changelog-unrelease.sh
@@ -8,8 +8,9 @@ function _changelogsh_unrelease {
   fi
 
   version=$1
+  expanded=$(_changelogsh_raw_to_expanded $1)
 
-  if [ ! -d "changelog/$version" ]; then
+  if [ ! -d "changelog/$expanded" ]; then
     printf "$version not found.\n"
     return
   fi
@@ -18,8 +19,8 @@ function _changelogsh_unrelease {
     mkdir 'changelog/unreleased'
   fi
 
-  mv changelog/$version/* changelog/unreleased/
-  rm -r changelog/$version
+  mv changelog/$expanded/* changelog/unreleased/
+  rm -r changelog/$expanded
 
   _changelogsh_preview
 }


### PR DESCRIPTION
WARNING: This has breaking changes!!!

Instead of having the directories like this:

```
changelog/
  0.0.1
  1.0.0
  1.1.0
  2.0.0
```

They are now presented like this:

```
changelog/
  000000001
  001000000
  001001000
  002000000
```